### PR TITLE
Bump for jessie-backports.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+alabaster (0.7.6-1~bpo8+1) jessie-backports; urgency=medium
+
+  * Rebuild for jessie-backports.
+
+ -- Harlan Lieberman-Berg <hlieberman@setec.io>  Wed, 25 Nov 2015 20:12:11 -0500
+
 alabaster (0.7.6-1) unstable; urgency=medium
 
   * Imported Upstream version 0.7.6


### PR DESCRIPTION
Hello Jeremy!

As part of backporting python-sphinx to jessie, I needed to backport alabaster as well.  It's a trivial backport; just bumping the version and rebuilding got a clean lintian build.

Thanks!

-Harlan
