### PR TITLE
Set priority to optional.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: alabaster
 Section: python
-Priority: extra
+Priority: optional
 Maintainer: Jeremy T. Bouse <jbouse@debian.org>
 Build-Depends: debhelper (>=9),
                dh-python,


### PR DESCRIPTION
This package cannot be `Priority: extra` because Sphinx depends on it.

Fixes errors in [debcheck](https://qa.debian.org/debcheck.php?dist=unstable&package=sphinx):

>  According to Policy [Section 2.5: Priorities](http://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities) packages MUST NOT depend on packages with lower priority values (excluding build-time dependencies) nor should packages of priority optional (or higher) conflict with each other. In order to ensure this, the priorities of one or more packages must be adjusted.
> 
> Package is optional and has a Depends on python3-alabaster (>= 0.7) which is extra on amd64.
